### PR TITLE
Fix harcoded home directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .venv
 .vagrant
 .terraform
+assets

--- a/installer/templates/master.sh.j2
+++ b/installer/templates/master.sh.j2
@@ -53,26 +53,26 @@ EOF
 sudo chmod 600 /etc/kubernetes/pki/etcd/server-key.pem
 
 # install ssh keys
-sudo tee /home/ubuntu/.ssh/id_rsa.pub > /dev/null <<EOF
+sudo tee $HOME/.ssh/id_rsa.pub > /dev/null <<EOF
 {% include cluster["sshKeysDir"] + "/" + master_name + "_rsa.pub" %}
 EOF
-sudo tee /home/ubuntu/.ssh/id_rsa > /dev/null <<EOF
+sudo tee $HOME/.ssh/id_rsa > /dev/null <<EOF
 {% include cluster["sshKeysDir"] + "/" + master_name + "_rsa" %}
 EOF
-sudo chmod 600 /home/ubuntu/.ssh/id_rsa
+sudo chmod 600 $HOME/.ssh/id_rsa
 
 #
 # allow master peers ssh access
 #
 {% for master in cluster["masters"] %}
-tee -a /home/ubuntu/.ssh/authorized_keys > /dev/null <<EOF
+tee -a $HOME/.ssh/authorized_keys > /dev/null <<EOF
 {% include cluster["sshKeysDir"] + "/" + master["nodeName"] + "_rsa.pub" %}
 EOF
 {% endfor %}
 
 # allow peers to ssh/scp as root
 sudo mkdir -p /root/.ssh
-cat /home/ubuntu/.ssh/authorized_keys | sudo tee -a /root/.ssh/authorized_keys > /dev/null
+cat $HOME/.ssh/authorized_keys | sudo tee -a /root/.ssh/authorized_keys > /dev/null
 
 
 #

--- a/installer/templates/worker.sh.j2
+++ b/installer/templates/worker.sh.j2
@@ -17,13 +17,13 @@ log INFO "installing kubeadm ..."
 {% include "fragments/kubeadm.sh.j2" %}
 
 # install ssh keys
-sudo tee /home/ubuntu/.ssh/id_rsa.pub > /dev/null <<EOF
+sudo tee $HOME/.ssh/id_rsa.pub > /dev/null <<EOF
 {% include cluster["sshKeysDir"] + "/" + worker_name + "_rsa.pub" %}
 EOF
-sudo tee /home/ubuntu/.ssh/id_rsa > /dev/null <<EOF
+sudo tee $HOME/.ssh/id_rsa > /dev/null <<EOF
 {% include cluster["sshKeysDir"] + "/" + worker_name + "_rsa" %}
 EOF
-sudo chmod 600 /home/ubuntu/.ssh/id_rsa
+sudo chmod 600 $HOME/.ssh/id_rsa
 
 #
 # Run kubeadm


### PR DESCRIPTION
This fixes the home directory being hardcoded to `/home/ubuntu`. It now uses `$HOME`.

Verified by running with `sshLoginUser` as `root`.

This also includes a separate commit that adds `assets` to the gitignore. I can remove this if you'd like, but it makes sense to me since that's the default assets location.