### PR TITLE
Allow less than 3 masters with a warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,7 @@ permitted by the json parser.**
     # (Optional) A private SSH login key to use when connecting to nodes.
     # Can be overridden on a per-node basis (see below).
     "sshLoginKey": "~/.ssh/id_rsa",
-    # The list of master nodes in the cluster. A minimum of 3 masters is
-    # required.
+    # The list of master nodes in the cluster.
     "masters": [
         {
             # The node's name.

--- a/hakubeinstaller/cluster.py
+++ b/hakubeinstaller/cluster.py
@@ -43,8 +43,7 @@ CLUSTER_DEFAULTS = {
     # (Optional) A private SSH login key to use when connecting to nodes.
     # Can be overridden on a per-node basis (see below).
     "sshLoginKey": None,
-    # The list of master nodes in the cluster. A minimum of 3 masters is
-    # required.
+    # The list of master nodes in the cluster.
     "masters": None,
     # The list of worker nodes in the cluster.
     "workers": None,
@@ -132,7 +131,7 @@ class ClusterDefinition:
         if not isinstance(masters, list):
             raise ValueError("'masters' expected to be a list")
         if len(masters) < 3:
-            raise ValueError("masters: a minimum of 3 masters must be specified")
+            LOG.warn("a minimum of 3 masters is required for high-availability")
         for master in masters:
             try:
                 self._validate_node(master)


### PR DESCRIPTION
This turns the error for less than 3 masters being provided into a warning.

The purpose is so that this tool can also be used for deploying non-HA clusters. I think this should be left up to a decision by the user so that the same tool can be used across all clusters.

The warning serves as a reminder that a cluster with < 3 masters will not be HA, but presumably almost all people that understand that they need this tool with all of its workarounds already have a basic understanding of requirements for HA.