### PR TITLE
Add option to pre generate certs

### DIFF
--- a/hakubeinstaller/create-kubeadm-certs.sh
+++ b/hakubeinstaller/create-kubeadm-certs.sh
@@ -1,0 +1,57 @@
+# default output_dir
+output_dir=$(realpath assets/pki)
+
+# change into default directory
+cd ${output_dir}
+
+cat > ${output_dir}/csr.json <<EOL
+{
+   "CN": "kubernetes",
+   "key": {
+       "algo": "rsa",
+       "size": 2048
+   }
+}
+EOL
+# create general ca, and ca for front-proxy
+cfssl gencert -initca csr.json | cfssljson -bare ca
+cfssl gencert -initca csr.json | cfssljson -bare front-proxy-ca
+
+cat > ${output_dir}/ca-config.json <<EOL
+{
+	"signing": {
+		"default": {
+			"expiry": "8760h"
+		},
+		"profiles": {
+			"kubernetes": {
+				"usages": ["signing", "key encipherment", "server auth", "client auth"],
+				"expiry": "8760h"
+			}
+		}
+	}
+}
+EOL
+
+cat > ${output_dir}/front-proxy-client.json <<EOL
+{
+   "CN": "front-proxy-client",
+   "key": {
+       "algo": "rsa",
+       "size": 2048
+   }
+}
+EOL
+
+# creates front proxy client cert
+cfssl gencert \
+    -ca=front-proxy-ca.pem \
+    -ca-key=front-proxy-ca-key.pem \
+    -config=ca-config.json \
+    -profile=kubernetes \
+    front-proxy-client.json | cfssljson -bare front-proxy-client
+
+
+# create service account key pair
+openssl req  -nodes -new -x509  -keyout sa.key -out sa.pub -subj "/AU=US"
+openssl rsa -in sa.key -pubout -out sa.pub

--- a/hakubeinstaller/main.py
+++ b/hakubeinstaller/main.py
@@ -21,7 +21,8 @@ def render(args):
     clusterdef = cluster.ClusterDefinition(cluster_path, assets_dir)
     clusterdef.render(
         overwrite_secrets=args.overwrite_secrets,
-        overwrite_scripts=args.overwrite_scripts)
+        overwrite_scripts=args.overwrite_scripts,
+        disable_ssh=args.disable_ssh)
 
 
 def install(args):
@@ -53,8 +54,8 @@ def cli():
         default="assets", help="Directory to which cluster scripts and certs "
         "will be written. Default: assets")
     parser_render.add_argument(
-        "--overwrite-secrets", dest="overwrite_secrets", action="store_true",
-        default=False,
+        "--overwrite-secrets", dest="overwrite_secrets",
+        action="store_true", default=False,
         help="Set if existing secrets (certs and keys) in the assets dir "
         "are to be overwritten. Default behavior: don't overwrite.")
     parser_render.add_argument(
@@ -62,6 +63,10 @@ def cli():
         action="store_false", default=True,
         help="Set if existing boot scripts in the assets dir are NOT to be "
         "overwritten. Default behavior: overwrite.")
+    parser_render.add_argument(
+        "--disable-ssh", dest="disable_ssh",
+        action="store_true", default=False,
+        help="Set if you do not want master nodes to have ssh access to each other")
     parser_render.set_defaults(handler=render)
 
     parser_install = subparsers.add_parser(

--- a/hakubeinstaller/templates/fragments/kubeadm-certs.sh.j2
+++ b/hakubeinstaller/templates/fragments/kubeadm-certs.sh.j2
@@ -1,0 +1,28 @@
+## install kubeadm CA certificate
+sudo tee /etc/kubernetes/pki/ca.crt > /dev/null <<EOF
+{% include cluster["PKIDir"] + "/ca.pem" %}
+EOF
+sudo tee /etc/kubernetes/pki/ca.key > /dev/null <<EOF
+{% include cluster["PKIDir"] + "/ca-key.pem" %}
+EOF
+
+sudo tee /etc/kubernetes/pki/front-proxy-ca.crt > /dev/null <<EOF
+{% include cluster["PKIDir"] + "/front-proxy-ca.pem" %}
+EOF
+sudo tee /etc/kubernetes/pki/front-proxy-ca.key > /dev/null <<EOF
+{% include cluster["PKIDir"] + "/front-proxy-ca-key.pem" %}
+EOF
+
+sudo tee /etc/kubernetes/pki/front-proxy-client.crt > /dev/null <<EOF
+{% include cluster["PKIDir"] + "/front-proxy-client.pem" %}
+EOF
+sudo tee /etc/kubernetes/pki/front-proxy-client.key > /dev/null <<EOF
+{% include cluster["PKIDir"] + "/front-proxy-client-key.pem" %}
+EOF
+
+sudo tee /etc/kubernetes/pki/sa.pub > /dev/null <<EOF
+{% include cluster["PKIDir"] + "/sa.pub" %}
+EOF
+sudo tee /etc/kubernetes/pki/sa.key > /dev/null <<EOF
+{% include cluster["PKIDir"] + "/sa.key" %}
+EOF

--- a/hakubeinstaller/templates/fragments/kubeadm.sh.j2
+++ b/hakubeinstaller/templates/fragments/kubeadm.sh.j2
@@ -1,5 +1,4 @@
 ## start: kubeadm.sh
-
 # swap must be disabled for kubelet to work properly
 sudo swapoff -a
 
@@ -30,13 +29,10 @@ EOF
 sudo systemctl daemon-reload
 sudo systemctl restart kubelet
 
-{% if cluster["hooks"].get("cloudProviderConfig") %}
+{%- if cluster["hooks"].get("cloudProviderConfig") %}
 # Add cloud-provider config (if one is required by the cloudprovider)
 sudo tee /etc/kubernetes/cloud-config.json > /dev/null <<EOF
 {% include "hooks/cloudconfig/" + cluster["hooks"].get("cloudProviderConfig") %}
 EOF
 {% endif %}
-
-
-
 ## end: kubeadm.sh

--- a/hakubeinstaller/templates/master.sh.j2
+++ b/hakubeinstaller/templates/master.sh.j2
@@ -52,6 +52,11 @@ sudo tee /etc/kubernetes/pki/etcd/server-key.pem > /dev/null <<EOF
 EOF
 sudo chmod 600 /etc/kubernetes/pki/etcd/server-key.pem
 
+
+{% if disable_ssh %}
+## install kubeadm CA certificate
+{% include "fragments/kubeadm-certs.sh.j2" %}
+{% else %}
 # install ssh keys
 sudo tee $HOME/.ssh/id_rsa.pub > /dev/null <<EOF
 {% include cluster["sshKeysDir"] + "/" + master_name + "_rsa.pub" %}
@@ -64,7 +69,7 @@ sudo chmod 600 $HOME/.ssh/id_rsa
 #
 # allow master peers ssh access
 #
-{% for master in cluster["masters"] %}
+{%- for master in cluster["masters"] %}
 tee -a $HOME/.ssh/authorized_keys > /dev/null <<EOF
 {% include cluster["sshKeysDir"] + "/" + master["nodeName"] + "_rsa.pub" %}
 EOF
@@ -73,6 +78,7 @@ EOF
 # allow peers to ssh/scp as root
 sudo mkdir -p /root/.ssh
 cat $HOME/.ssh/authorized_keys | sudo tee -a /root/.ssh/authorized_keys > /dev/null
+{% endif %}
 
 
 #
@@ -152,8 +158,7 @@ until etcdctl member list; do
     sleep 3
 done
 
-
-{% if master != cluster["masters"][0] %}
+{%- if not disable_ssh and master != cluster["masters"][0] %}
 # Wait for seed master to generate necessary certificates. This includes the
 # k8s ca cert, which must be used to sign kubeadm-generated apiserver certs.
 # https://github.com/kubernetes/kubeadm/blob/master/docs/design/design_v1.7.md
@@ -167,7 +172,6 @@ retrying_scp root@{{ cluster["masters"][0]["privateIP"] }} /etc/kubernetes/pki/f
 retrying_scp root@{{ cluster["masters"][0]["privateIP"] }} /etc/kubernetes/pki/front-proxy-client.crt
 retrying_scp root@{{ cluster["masters"][0]["privateIP"] }} /etc/kubernetes/pki/front-proxy-client.key
 {% endif %}
-
 
 #
 # Run kubeadm


### PR DESCRIPTION
This PR adds the flag ` --disable-ssh` for the render command,

Usage: 
`hakube-installer render cluster.json --disable-ssh`

This allows the user to choose if they want to allow ssh access between hosts. If they do not want to allow this, all shared kubeadm certs are generated upfront to be passed to all masters in the install script. Passing in certs also gets rid of inter-node dependence. While the certs could be pregenerate using  `kubeadm`, I am using cfssl instead as the design decision is to not have to rely on `kubeadm`.



